### PR TITLE
Force `du` to also report hardlinks

### DIFF
--- a/src/sbin/diskspace_usage.sh
+++ b/src/sbin/diskspace_usage.sh
@@ -8,4 +8,4 @@ fi
 
 cd "$1"
 
-du -a -d 1 || echo ""
+du -al -d 1 || echo ""


### PR DESCRIPTION
In newer versions hardlinks is hidden by default