### PR TITLE
Improve performance of the scheduled task

### DIFF
--- a/src/sbin/files.sh
+++ b/src/sbin/files.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-find / -type f -print0 | xargs -0 du | sort -n | tail -50 | cut -f2 | xargs -I{} du -bs {}
+find / -path /proc -prune -o -path /sys -prune -o -type f -size +512k -printf '%s\t%p\n' | sort -n | tail -n 50


### PR DESCRIPTION
Current implementation of the scheduled task's `/sbin/` script is not optimized:
``` bash
$ time find / -type f -print0 | xargs -0 du | sort -n | tail -50 | cut -f2 | xargs -I{} du -bs {} >/dev/null
du: cannot access '/proc/11685/task/11685/fdinfo/17': No such file or directory
du: cannot access '/proc/11685/task/11685/fdinfo/20': No such file or directory
du: cannot access '/proc/11685/fdinfo/17': No such file or directory
du: cannot access '/proc/11685/fdinfo/20': No such file or directory
find: ‘/proc/20595/task/20595/net’: Invalid argument
find: ‘/proc/20595/net’: Invalid argument
find: ‘/proc/23253’: No such file or directory
find: ‘/proc/23255’: No such file or directory
find: ‘/proc/23416’: No such file or directory
du: cannot access '/proc/23256/task/23256/fdinfo/10': No such file or directory
du: cannot access '/proc/23256/fdinfo/5': No such file or directory
find / -type f -print0  3.78s user 7.27s system 13% cpu 1:19.45 total
xargs -0 du  14.56s user 14.30s system 36% cpu 1:19.51 total
sort -n  58.28s user 5.55s system 76% cpu 1:23.62 total
tail -50  0.12s user 0.18s system 0% cpu 1:23.61 total
cut -f2  0.00s user 0.00s system 0% cpu 1:23.61 total
xargs -I{} du -bs {} > /dev/null  0.00s user 0.01s system 0% cpu 1:23.71 total
```

Adding at least a filter for the `/proc` and `/sys` directories and getting rid of unnecessary command invocations gives ~40% improvement:
```bash
$ time find / -path /proc -prune -o -path /sys -prune -o -type f -exec du -bs {} + | sort -n | tail -n 50 >/dev/null
find / -path /proc -prune -o -path /sys -prune -o -type f -exec du -bs {} +  14.15s user 18.35s system 71% cpu 45.749 total
sort -n  16.04s user 5.73s system 43% cpu 49.929 total
tail -n 50 > /dev/null  0.07s user 0.16s system 0% cpu 49.928 total
```

Further optimization by filtering out all files smaller than 512KiB (unlikely that they matter in the output) speeds up execution to 20% of the original command's:
```bash
$ time find / -path /proc -prune -o -path /sys -prune -o -type f -size +512k -exec du -bs {} + | sort -n | tail -50 >/dev/null
find / -path /proc -prune -o -path /sys -prune -o -type f -size +512k -exec d  6.87s user 9.73s system 99% cpu 16.707 total
sort -n  0.02s user 0.02s system 0% cpu 16.724 total
tail -50 > /dev/null  0.00s user 0.00s system 0% cpu 16.723 total
```

While we're at here, we can also replace `du` with inlined `-printf` call: we can modify the output of the latter and change the delimiter to `'\0'`, if necessary; it also wins us a little bit of the execution time:
```bash
$ time find / -path /proc -prune -o -path /sys -prune -o -type f -size +512k -printf '%s\t%p\n' | sort -n | tail -n 50 >/dev/null       
find / -path /proc -prune -o -path /sys -prune -o -type f -size +512k -printf  6.45s user 10.05s system 99% cpu 16.592 total
sort -n  0.04s user 0.00s system 0% cpu 16.626 total
tail -n 50 > /dev/null  0.00s user 0.00s system 0% cpu 16.623 total
```